### PR TITLE
Update requirements and allow_redirects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@
 
 PyYAML==3.10
 UnittestZero
+beautifulsoup4==4.0.4
 certifi==0.0.8
+chardet==1.0.1
 execnet==1.0.9
 py==1.4.7
 pytest==2.2.3
 pytest-mozwebqa==0.8
 pytest-xdist==1.8
-requests==0.9.1
-selenium
-BeautifulSoup4
+requests==0.11.1

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -33,7 +33,7 @@ class TestSnippets:
                    'accept-language': locale}
 
         # HEAD doesn't return page body.
-        r = requests.head(url, headers=headers, verify=False, timeout=5)
+        r = requests.head(url, headers=headers, timeout=5, allow_redirects=True, verify=False)
         return Assert.equal(r.status_code, requests.codes.ok,
                             'Bad URL %s found in %s' % (url, path))
 


### PR DESCRIPTION
Most of this bug seemed to be the difference between 0.9.1 and 0.11.1 of requests. A test with python console with each version showed that 0.9.1 caused the error we were seeing in Jenkins.

but I set the allow_redirects flag anyway.
