### PR TITLE
Added lxml to requirements.txt so bs4 could use it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 PyYAML==3.10
 UnittestZero
-beautifulsoup4==4.0.4
+beautifulsoup4==4.1.3
 certifi==0.0.8
 chardet==1.0.1
 py==1.4.9
@@ -12,4 +12,4 @@ pytest-mozwebqa==1.0
 pytest-xdist==1.8
 requests==0.11.1
 selenium
-lxml
+html5lib==0.95


### PR DESCRIPTION
This should fix the failure on prod. Note that to test this locally one will have to pip install requirements.txt as that will cause it to install the missing lxml. This addresses issue #11.
