### PR TITLE
Exclude about protocol links from check

### DIFF
--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -67,7 +67,8 @@ class TestSnippets:
         snippet_links = soup.select("a")
 
         for link in snippet_links:
-            self.assert_valid_url(link['href'], path)
+            if "about:" not in link['href']:
+                self.assert_valid_url(link['href'], path)
 
     @pytest.mark.parametrize(('path'), test_data)
     def test_that_snippets_are_well_formed_xml(self, mozwebqa, path):


### PR DESCRIPTION
[snippets.prod](http://selenium.qa.mtv2.mozilla.com:8080/job/snippets.prod/49739/console) started failing because it could not get a request on an "about:" link.
I added an if to ignore these links since I don't know of a way to check them.

@stephendonner Do you know if it's possible to perform a get request on these links?
