### PR TITLE
Remove pytest mozwebqa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cache
+__pycache__
+*.pyc

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption('--base-url',
+                     default='https://snippets.allizom.org',
+                     help='base url for the snippets instance.')
+
+
+@pytest.fixture
+def base_url(request):
+    return request.config.option.base_url

--- a/mozwebqa.cfg
+++ b/mozwebqa.cfg
@@ -1,4 +1,0 @@
-[DEFAULT]
-api = webdriver
-baseurl = https://snippets.allizom.org
-tags = snippets-tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,4 @@
-# This pulls in all the libraries needed to run Selenium tests
-# on Mozilla WebQA projects
-
-PyYAML==3.10
 UnittestZero
-beautifulsoup4==4.1.3
-certifi==0.0.8
-chardet==2.1.1
-py==1.4.9
-pytest==2.2.4
-pytest-mozwebqa
-pytest-xdist==1.8
-requests==2.4.3
-pyOpenSSL
-ndg-httpsclient
-pyasn1
-selenium
-html5lib==0.95
+beautifulsoup4==4.4.1
+pytest==2.7.3
+requests==2.8.1

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -16,8 +15,6 @@ import requests
 REQUESTS_TIMEOUT = 20
 
 
-@pytest.mark.skip_selenium
-@pytest.mark.nondestructive
 class TestSnippets:
 
     test_data = [
@@ -57,8 +54,8 @@ class TestSnippets:
         return BeautifulSoup(content)
 
     @pytest.mark.parametrize(('path'), test_data)
-    def test_snippet_set_present(self, mozwebqa, path):
-        full_url = mozwebqa.base_url + path
+    def test_snippet_set_present(self, base_url, path):
+        full_url = base_url + path
 
         r = self._get_redirect(full_url)
         Assert.equal(r.status_code, requests.codes.ok, "URL %s failed with status code: %s" % (full_url, r.status_code))
@@ -69,8 +66,8 @@ class TestSnippets:
         Assert.greater(len(snippet_set), 0, "No snippet set found")
 
     @pytest.mark.parametrize(('path'), test_data)
-    def test_all_links(self, mozwebqa, path):
-        full_url = mozwebqa.base_url + path
+    def test_all_links(self, base_url, path):
+        full_url = base_url + path
 
         soup = self._parse_response(self._get_redirect(full_url).content)
         snippet_links = soup.select("a")
@@ -79,11 +76,11 @@ class TestSnippets:
             self.assert_valid_url(link['href'], path)
 
     @pytest.mark.parametrize(('path'), test_data)
-    def test_that_snippets_are_well_formed_xml(self, mozwebqa, path):
-        if 'snippets.mozilla.com' not in mozwebqa.base_url:
+    def test_that_snippets_are_well_formed_xml(self, base_url, path):
+        if 'snippets.mozilla.com' not in base_url:
             pytest.skip('Only test well formedness on production.')
 
-        full_url = mozwebqa.base_url + path
+        full_url = base_url + path
 
         r = self._get_redirect(full_url)
 


### PR DESCRIPTION
We're not using any features from pytest-mozwebqa in these tests, so it seems silly to use it. This patch replaces it with a simple fixture that provides a base URL that can be set on the command line. I've also cleaned up the requirements, which addresses #30.