### PR TITLE
Update tests to comply with isolated snippets

### DIFF
--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -86,9 +86,8 @@ class TestSnippets:
         full_url = base_url + path
 
         r = self._get_redirect(full_url)
-
         try:
-            parseString(r.content)
+            parseString('<div>{}</div>'.format(r.content))
         except ExpatError as e:
             raise AssertionError('Snippets at {0} do not contain well formed '
                                  'xml: {1}'.format(full_url, e))

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -69,7 +69,7 @@ class TestSnippets:
         snippet_json_string = re.search("JSON.parse\('(.+)'\)", snippet_script).groups()[0]
         snippet_set = json.loads(snippet_json_string.replace('%u', r'\u').decode('unicode-escape'))
 
-        assert len(snippet_set) > 0, 'No snippet set found'
+        assert isinstance(snippet_set, list), 'No snippet set found'
 
     @pytest.mark.parametrize(('path'), test_data)
     def test_all_links(self, base_url, path):

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -83,9 +83,6 @@ class TestSnippets:
 
     @pytest.mark.parametrize(('path'), test_data)
     def test_that_snippets_are_well_formed_xml(self, base_url, path):
-        if 'snippets.mozilla.com' not in base_url:
-            pytest.skip('Only test well formedness on production.')
-
         full_url = base_url + path
 
         r = self._get_redirect(full_url)


### PR DESCRIPTION
Since https://github.com/mozilla/snippets-service/pull/128 snippet_set is a JSON list which will be empty when no snippets are served. Change the test to just make sure that there is a list available and don't worry about its size.

Also we need to wrap responses in a div to make them XML valid.