### PR TITLE
Upgrade fxtest shared library to 1.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest@1.2') _
+@Library('fxtest@1.3') _
 
 pipeline {
   agent any


### PR DESCRIPTION
Upgrade fxtest shared library to 1.3 so failure to submit to ActiveData will not mark builds as unstable. Passing adhoc: http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/snippets.adhoc/30/